### PR TITLE
Ignore test folder in coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "test/"


### PR DESCRIPTION
This fixes #110 

After merging this, at the bottom of the codecov report you should see that the `tests/` folder isn't listed.

You can add a bunch of other codecov tweaks to your liking in the new dot file :)